### PR TITLE
fix: support chromebook arm64 linux

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -38,7 +38,7 @@ download_release() {
 	version="$1"
 	filename="$2"
 	arch="$(uname -m)"
-	if [[ "$arch" == 'arm64' ]]; then
+	if [[ "$arch" == 'arm64' || "$arch" == 'aarch64' ]]; then
 		arch='aarch64'
 	else
 		arch='x86_64'


### PR DESCRIPTION
On my chromebook arm64 linux, `uname -m` returns `aarch64`.